### PR TITLE
Update configure and source code for compatibility with guile-3.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: release-archive
-          path: 'libmatheval-1.1.12.tar.gz'
+          path: 'libmatheval-1.1.13.tar.gz'
       - name: Upload docs artifact
         uses: actions/upload-artifact@v6
         with:
@@ -68,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload latest libmatheval-1.1.12.tar.gz --clobber
+          gh release upload latest libmatheval-1.1.13.tar.gz --clobber
       - name: Update tag
         run: |
           git tag -f latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Generate configure
         run: |
           cd $GITHUB_WORKSPACE
-          apt update
-          apt install -y build-essential bison flex gettext gcc guile-3.0 guile-3.0-dev texinfo
+          sudo apt update
+          sudo apt install -y build-essential bison flex gettext gcc guile-3.0 guile-3.0-dev texinfo
           git config --global --add safe.directory $GITHUB_WORKSPACE
           set -o pipefail
           mkdir -p config

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,6 @@ jobs:
   # Build and test
   Build-and-Test:
     runs-on: ubuntu-latest
-    container: ghcr.io/galacticusorg/buildenv:latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v6
@@ -23,14 +22,14 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           apt update
-          apt install -y bison flex
+          apt install -y build-essential bison flex gettext gcc guile-3.0 guile-3.0-dev texinfo
           git config --global --add safe.directory $GITHUB_WORKSPACE
           set -o pipefail
           mkdir -p config
           mkdir -p m4
           touch config/config.rpath
           autoreconf --install --force -I/usr/local/share/aclocal
-          CFLAGS="-I/usr/include/x86_64-linux-gnu" ./configure
+          CFLAGS="-I/usr/include/x86_64-linux-gnu -I/usr/include/guile/3.0/" ./configure
           make dist
           cd doc
           make libmatheval.html

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,7 +48,7 @@ jobs:
           make -j4 2>&1 | tee build.log
           grep -v -q Error: build.log
           grep -v -q Warning: build.log
-          make -j4 install
+          sudo make -j4 install
           (make -j4 check || { cat tests/testsuite.log; exit 1; }) 2>&1 | tee build.log
           grep -v -q Error: build.log
           grep -v -q Warning: build.log

--- a/configure.in
+++ b/configure.in
@@ -19,11 +19,11 @@ dnl <http://www.gnu.org/licenses/>.
 
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([libmatheval],[1.1.12],[asamardzic@gnu.org])
+AC_INIT([libmatheval],[1.1.13],[abensonca@gmail.com])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([ac_aux_dir])
-AM_INIT_AUTOMAKE([libmatheval], [1.1.12])
+AM_INIT_AUTOMAKE([libmatheval], [1.1.13])
 AC_CONFIG_SRCDIR([configure.in])
 AM_CONFIG_HEADER([config.h])
 
@@ -61,9 +61,9 @@ AC_CHECK_FUNCS([bzero memset], [break])
 
 dnl Additional Guile feature checks.
 AC_CHECK_TYPE([scm_t_bits], [AC_DEFINE([HAVE_SCM_T_BITS], [1], [Define to 1 if you have the `scm_t_bits' type.])], [], [#include <libguile.h>])
-AC_CHECK_LIB([guile], [scm_c_define_gsubr], [AC_DEFINE([HAVE_SCM_C_DEFINE_GSUBR], [1], [Define to 1 if you have the `scm_c_define_gsubr' function.])], [], [$GUILE_LDFLAGS])
-AC_CHECK_LIB([guile], [scm_make_gsubr], [AC_DEFINE([HAVE_SCM_MAKE_GSUBR], [1], [Define to 1 if you have the `scm_make_gsubr' function.])], [], [$GUILE_LDFLAGS])
-AC_CHECK_LIB([guile], [scm_num2dbl], [AC_DEFINE([HAVE_SCM_NUM2DBL], [1], [Define to 1 if you have the `scm_num2dbl' function.])], [], [$GUILE_LDFLAGS])
+AC_CHECK_LIB([guile-3.0], [scm_c_define_gsubr], [AC_DEFINE([HAVE_SCM_C_DEFINE_GSUBR], [1], [Define to 1 if you have the `scm_c_define_gsubr' function.])], [], [$GUILE_LDFLAGS])
+AC_CHECK_LIB([guile-3.0], [scm_make_gsubr], [AC_DEFINE([HAVE_SCM_MAKE_GSUBR], [1], [Define to 1 if you have the `scm_make_gsubr' function.])], [], [$GUILE_LDFLAGS])
+AC_CHECK_LIB([guile-3.0], [scm_to_double], [AC_DEFINE([HAVE_SCM_TO_DOUBLE], [1], [Define to 1 if you have the `scm_to_double' function.])], [], [$GUILE_LDFLAGS])
 
 AC_CONFIG_FILES([Makefile doc/Makefile lib/Makefile])
 AC_CONFIG_FILES([libmatheval.pc])

--- a/tests/basics.at
+++ b/tests/basics.at
@@ -62,7 +62,7 @@ AT_DATA([basics.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh basics.scm], [ignore], [10.0], [ignore])
+AT_CHECK([matheval.sh basics.scm], [ignore], [10.000000000000002], [ignore])
 
 AT_DATA([basics.scm],
 [[
@@ -70,7 +70,7 @@ AT_DATA([basics.scm],
 (display (evaluator-evaluate-x f 0.7))
 ]])
 
-AT_CHECK([matheval.sh basics.scm], [ignore], [0.220966666722528], [ignore])
+AT_CHECK([matheval.sh basics.scm], [ignore], [0.22096666672252796], [ignore])
 
 AT_DATA([basics.scm],
 [[
@@ -78,7 +78,7 @@ AT_DATA([basics.scm],
 (display (evaluator-evaluate-x-y f 0.4 -0.7))
 ]])
 
-AT_CHECK([matheval.sh basics.scm], [ignore], [-1.14962406520749], [ignore])
+AT_CHECK([matheval.sh basics.scm], [ignore], [-1.1496240652074883], [ignore])
 
 AT_DATA([basics.scm],
 [[
@@ -86,7 +86,7 @@ AT_DATA([basics.scm],
 (display (evaluator-evaluate-x-y-z f 11.2 0.41 -0.66))
 ]])
 
-AT_CHECK([matheval.sh basics.scm], [ignore], [3.99876152571934], [ignore])
+AT_CHECK([matheval.sh basics.scm], [ignore], [3.9987615257193383], [ignore])
 
 AT_DATA([basics.scm],
 [[

--- a/tests/constants.at
+++ b/tests/constants.at
@@ -29,7 +29,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [2.71828182845905], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [2.718281828459045], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -37,7 +37,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [1.44269504088896], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [1.4426950408889634], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -45,7 +45,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [0.434294481903252], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [0.4342944819032518], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -53,7 +53,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [0.693147180559945], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [0.6931471805599453], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -61,7 +61,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [2.30258509299405], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [2.302585092994046], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -69,7 +69,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [3.14159265358979], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [3.141592653589793], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -77,7 +77,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [1.5707963267949], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [1.5707963267948966], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -85,7 +85,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [0.785398163397448], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [0.7853981633974483], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -93,7 +93,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [0.318309886183791], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [0.3183098861837907], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -101,7 +101,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [0.636619772367581], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [0.6366197723675814], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -109,7 +109,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [1.12837916709551], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [1.1283791670955126], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -117,7 +117,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [1.4142135623731], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [1.4142135623730951], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -125,7 +125,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [0.707106781186548], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [0.7071067811865476], [ignore])
 
 AT_DATA([constant.scm],
 [[
@@ -133,7 +133,7 @@ AT_DATA([constant.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh constant.scm], [ignore], [10.0], [ignore])
+AT_CHECK([matheval.sh constant.scm], [ignore], [10.000000000000002], [ignore])
 
 AT_DATA([constant.scm],
 [[

--- a/tests/functions.at
+++ b/tests/functions.at
@@ -29,7 +29,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [2.71828182845905], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [2.718281828459045], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -80,7 +80,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.841470984807897], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.8414709848078965], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -97,7 +97,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.54030230586814], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.5403023058681398], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -114,7 +114,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.5574077246549], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.5574077246549023], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -131,7 +131,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.642092615934331], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.6420926159343306], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -148,7 +148,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.85081571768093], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.8508157176809255], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -165,7 +165,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.18839510577812], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.1883951057781212], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -182,7 +182,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267949], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267948966], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -216,7 +216,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.785398163397448], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.7853981633974483], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -233,7 +233,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.785398163397448], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.7853981633974483], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -267,7 +267,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267949], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.5707963267948966], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -284,7 +284,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.1752011936438], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.1752011936438014], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -301,7 +301,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.54308063481524], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.5430806348152437], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -318,7 +318,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.761594155955765], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.7615941559557649], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -335,7 +335,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [1.31303528549933], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [1.3130352854993315], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -352,7 +352,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.648054273663885], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.6480542736638855], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -368,7 +368,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.850918128239322], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.8509181282393216], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -385,7 +385,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.881373587019543], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.8813735870195429], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -419,7 +419,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 0.5))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.549306144334055], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.5493061443340549], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -436,7 +436,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 2))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.549306144334055], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.5493061443340549], [ignore])
 
 AT_DATA([function.scm],
 [[
@@ -470,7 +470,7 @@ AT_DATA([function.scm],
 (display (evaluator-evaluate-x f 1))
 ]])
 
-AT_CHECK([matheval.sh function.scm], [ignore], [0.881373587019543], [ignore])
+AT_CHECK([matheval.sh function.scm], [ignore], [0.8813735870195429], [ignore])
 
 AT_DATA([function.scm],
 [[

--- a/tests/matheval.c
+++ b/tests/matheval.c
@@ -30,12 +30,8 @@
 typedef long    scm_t_bits;
 #endif
 
-#ifndef HAVE_SCM_NUM2DBL
-#ifdef SCM_NUM2DBL
-#define scm_num2dbl(x,s) SCM_NUM2DBL(x)
-#else
-#error Neither scm_num2dbl() nor SCM_NUM2DBL available
-#endif
+#ifndef HAVE_SCM_TO_DOUBLE
+#error scm_to_double() is not available
 #endif
 
 #ifndef HAVE_SCM_C_DEFINE_GSUBR
@@ -51,7 +47,7 @@ static scm_t_bits evaluator_tag;	/* Unique identifier for Guile
 
 /* Guile interface for libmatheval library.  Procedures below are simple
  * wrappers for corresponding libmatheval procedures. */
-static scm_sizet evaluator_destroy_scm(SCM evaluator_smob);
+static size_t evaluator_destroy_scm(SCM evaluator_smob);
 static SCM      evaluator_create_scm(SCM string);
 static SCM      evaluator_evaluate_scm(SCM evaluator_smob, SCM count,
 				       SCM names, SCM values);
@@ -104,7 +100,7 @@ inner_main(void *closure, int argc, char **argv)
 
 	/* Interpret Guile code from file with name given through above
 	 * argument.  */
-	scm_primitive_load(scm_makfrom0str(argv[1]));
+	scm_primitive_load(scm_from_locale_string(argv[1]));
 }
 
 /* Program is demonstrating use of libmatheval library of procedures for
@@ -122,7 +118,7 @@ main(int argc, char **argv)
 }
 
 /* Wrapper for evaluator_destroy() procedure from libmatheval library. */
-static          scm_sizet
+static          size_t
 evaluator_destroy_scm(SCM evaluator_smob)
 {
 	SCM_ASSERT((SCM_NIMP(evaluator_smob)
@@ -142,12 +138,12 @@ evaluator_create_scm(SCM string)
 	void           *evaluator;
 
 	SCM_ASSERT(SCM_NIMP(string)
-		   && SCM_STRINGP(string), string, SCM_ARG1,
+		   && scm_is_string(string), string, SCM_ARG1,
 		   "evaluator-create");
 
-	stringz = (char *) malloc((SCM_LENGTH(string) + 1) * sizeof(char));
-	memcpy(stringz, SCM_CHARS(string), SCM_LENGTH(string));
-	stringz[SCM_LENGTH(string)] = 0;
+	stringz = (char *) malloc((scm_c_string_length(string) + 1) * sizeof(char));
+	memcpy(stringz, scm_to_latin1_string(string), scm_c_string_length(string));
+	stringz[scm_c_string_length(string)] = 0;
 
 	evaluator = evaluator_create(stringz);
 
@@ -174,43 +170,43 @@ evaluator_evaluate_scm(SCM evaluator_smob, SCM count, SCM names,
 	SCM_ASSERT((SCM_NIMP(evaluator_smob)
 		    && SCM_SMOB_PREDICATE(evaluator_tag, evaluator_smob)),
 		   evaluator_smob, SCM_ARG1, "evaluator-evaluate");
-	SCM_ASSERT(SCM_INUMP(count), count, SCM_ARG2,
+	SCM_ASSERT(scm_is_integer(count), count, SCM_ARG2,
 		   "evaluator-evaluate");
 
-	names_copy = (char **) malloc(SCM_INUM(count) * sizeof(char *));
-	for (i = 0, name = names; i < SCM_INUM(count);
+	names_copy = (char **) malloc(scm_to_int(count) * sizeof(char *));
+	for (i = 0, name = names; i < scm_to_int(count);
 	     i++, name = SCM_CDR(name)) {
 		SCM_ASSERT(SCM_NIMP(name) && SCM_CONSP(name)
-			   && SCM_STRINGP(SCM_CAR(name)), names, SCM_ARG3,
+			   && scm_is_string(SCM_CAR(name)), names, SCM_ARG3,
 			   "evaluator-evaluate");
 		names_copy[i] =
-		    (char *) malloc((SCM_LENGTH(SCM_CAR(name)) + 1) *
+		    (char *) malloc((scm_c_string_length(SCM_CAR(name)) + 1) *
 				    sizeof(char));
-		memcpy(names_copy[i], SCM_CHARS(SCM_CAR(name)),
-		       SCM_LENGTH(SCM_CAR(name)));
-		names_copy[i][SCM_LENGTH(SCM_CAR(name))] = 0;
+		memcpy(names_copy[i], scm_to_latin1_string(SCM_CAR(name)),
+		       scm_c_string_length(SCM_CAR(name)));
+		names_copy[i][scm_c_string_length(SCM_CAR(name))] = 0;
 	}
 
-	values_copy = (double *) malloc(SCM_INUM(count) * sizeof(double));
-	for (i = 0, value = values; i < SCM_INUM(count);
+	values_copy = (double *) malloc(scm_to_int(count) * sizeof(double));
+	for (i = 0, value = values; i < scm_to_int(count);
 	     i++, value = SCM_CDR(value)) {
 		SCM_ASSERT(SCM_NIMP(value) && SCM_CONSP(value)
 			   && SCM_NUMBERP(SCM_CAR(value)), values,
 			   SCM_ARG4, "evaluator-evaluate");
 		values_copy[i] =
-		    scm_num2dbl(SCM_CAR(value), "evaluator-evaluate");
+		    scm_to_double(SCM_CAR(value));
 	}
 
 	result =
 	    evaluator_evaluate((void *) SCM_CDR(evaluator_smob),
-			       SCM_INUM(count), names_copy, values_copy);
+			       scm_to_int(count), names_copy, values_copy);
 
-	for (i = 0; i < SCM_INUM(count); i++)
+	for (i = 0; i < scm_to_int(count); i++)
 		free(names_copy[i]);
 	free(names_copy);
 	free(values_copy);
 
-	return scm_make_real(result);
+	return scm_from_double(result);
 }
 
 /* Wrapper for evaluator_get_string() procedure from libmatheval library. */
@@ -222,7 +218,7 @@ evaluator_get_string_scm(SCM evaluator_smob)
 		   evaluator_smob, SCM_ARG1, "evaluator-get-string");
 
 	return
-	    scm_makfrom0str(evaluator_get_string
+	    scm_from_locale_string(evaluator_get_string
 			    ((void *) SCM_CDR(evaluator_smob)));
 }
 
@@ -245,9 +241,9 @@ evaluator_get_variables_scm(SCM evaluator_smob)
 	list = SCM_EOL;
 	for (i = 0; i < count; i++)
 		list =
-		    scm_append_x(scm_listify
+		    scm_append_x(scm_list_n
 				 (list,
-				  scm_listify(scm_makfrom0str(names[i]),
+				  scm_list_n(scm_from_locale_string(names[i]),
 					      SCM_UNDEFINED),
 				  SCM_UNDEFINED));
 
@@ -262,12 +258,12 @@ evaluator_derivative_scm(SCM evaluator_smob, SCM name)
 		    && SCM_SMOB_PREDICATE(evaluator_tag, evaluator_smob)),
 		   evaluator_smob, SCM_ARG1, "evaluator-derivative");
 	SCM_ASSERT(SCM_NIMP(name)
-		   && SCM_STRINGP(name), name, SCM_ARG2,
+		   && scm_is_string(name), name, SCM_ARG2,
 		   "evaluator-derivative");
 	SCM_RETURN_NEWSMOB(evaluator_tag,
 			   evaluator_derivative((void *)
 						SCM_CDR(evaluator_smob),
-						SCM_CHARS(name)));
+						scm_to_latin1_string(name)));
 }
 
 /* Wrapper for evaluator_evaluate_x() procedure from libmatheval library. */
@@ -279,9 +275,9 @@ evaluator_evaluate_x_scm(SCM evaluator_smob, SCM x)
 		   evaluator_smob, SCM_ARG1, "evaluator-evaluate-x");
 	SCM_ASSERT(SCM_NUMBERP(x), x, SCM_ARG2, "evaluator-evaluate-x");
 	return
-	    scm_make_real(evaluator_evaluate_x
+	    scm_from_double(evaluator_evaluate_x
 			  ((void *) SCM_CDR(evaluator_smob),
-			   scm_num2dbl(x, "evaluator-evaluate-x")));
+			   scm_to_double(x)));
 }
 
 /* Wrapper for evaluator_evaluate_x_y() procedure from libmatheval
@@ -295,10 +291,10 @@ evaluator_evaluate_x_y_scm(SCM evaluator_smob, SCM x, SCM y)
 	SCM_ASSERT(SCM_NUMBERP(x), x, SCM_ARG2, "evaluator-evaluate-x-y");
 	SCM_ASSERT(SCM_NUMBERP(y), y, SCM_ARG3, "evaluator-evaluate-x-y");
 	return
-	    scm_make_real(evaluator_evaluate_x_y
+	    scm_from_double(evaluator_evaluate_x_y
 			  ((void *) SCM_CDR(evaluator_smob),
-			   scm_num2dbl(x, "evaluator-evaluate-x-y"),
-			   scm_num2dbl(y, "evaluator-evaluate-x-y")));
+			   scm_to_double(x),
+			   scm_to_double(y)));
 }
 
 /* Wrapper for evaluator_evaluate_x_y_z() procedure from libmatheval
@@ -316,11 +312,11 @@ evaluator_evaluate_x_y_z_scm(SCM evaluator_smob, SCM x, SCM y, SCM z)
 	SCM_ASSERT(SCM_NUMBERP(z), z, SCM_ARG4,
 		   "evaluator-evaluate-x-y-z");
 	return
-	    scm_make_real(evaluator_evaluate_x_y_z
+	    scm_from_double(evaluator_evaluate_x_y_z
 			  ((void *) SCM_CDR(evaluator_smob),
-			   scm_num2dbl(x, "evaluator-evaluate-x-y-z"),
-			   scm_num2dbl(y, "evaluator-evaluate-x-y-z"),
-			   scm_num2dbl(z, "evaluator-evaluate-x-y-z")));
+			   scm_to_double(x),
+			   scm_to_double(y),
+			   scm_to_double(z)));
 }
 
 /* Wrapper for evaluator_derivative_x() procedure from libmatheval

--- a/tests/numbers.at
+++ b/tests/numbers.at
@@ -53,6 +53,6 @@ AT_DATA([number.scm],
 (display (evaluator-evaluate-x f 0))
 ]])
 
-AT_CHECK([matheval.sh number.scm], [ignore], [0.644394014977254], [ignore])
+AT_CHECK([matheval.sh number.scm], [ignore], [0.6443940149772542], [ignore])
 
 AT_CLEANUP

--- a/tests/package.m4
+++ b/tests/package.m4
@@ -1,6 +1,6 @@
 # Signature of the current package.
 m4_define([AT_PACKAGE_NAME],      [libmatheval])
 m4_define([AT_PACKAGE_TARNAME],   [libmatheval])
-m4_define([AT_PACKAGE_VERSION],   [1.1.12])
-m4_define([AT_PACKAGE_STRING],    [libmatheval 1.1.12])
-m4_define([AT_PACKAGE_BUGREPORT], [abenson@carnegiescience.edu])
+m4_define([AT_PACKAGE_VERSION],   [1.1.13])
+m4_define([AT_PACKAGE_STRING],    [libmatheval 1.1.13])
+m4_define([AT_PACKAGE_BUGREPORT], [abensonca@gmail.com])


### PR DESCRIPTION
* Adjust test targets to match improved precision from guile-3.0.
* Switch to using a base Ubuntu runner for CI/CD.
* Update release version to 1.1.13.